### PR TITLE
Wrap configs in Result[]

### DIFF
--- a/koneko/lscat.py
+++ b/koneko/lscat.py
@@ -34,13 +34,12 @@ def ycoords(term_height, img_height=8, padding=1):
             for row in range(number_of_rows)]
 
 
-def _width_paddingx():
+def _width_paddingx() -> int:
     settings = utils.get_config_section('lscat')
-    if not settings:
-        return 18, 2
-    img_width = settings.getint('image_width', fallback=18)
-    paddingx = settings.getint('images_x_spacing', fallback=2)
-    return img_width, paddingx
+    return (
+        settings.map(lambda s: s.getint('image_width', fallback=18)).value_or(18),
+        settings.map(lambda s: s.getint('images_x_spacing', fallback=2)).value_or(2)
+    )
 
 def ncols_config():
     return ncols(TERM.width, *_width_paddingx())
@@ -50,37 +49,40 @@ def xcoords_config(offset=0):
 
 def ycoords_config():
     settings = utils.get_config_section('lscat')
-    if not settings:
-        return ycoords(TERM.height, 8, 1)
-    img_height = settings.getint('image_height', fallback=8)
-    paddingy = settings.getint('images_y_spacing', fallback=1)
+    img_height = settings.map(
+        lambda s: s.getint('image_height', fallback=8)
+    ).value_or(8)
+    paddingy = settings.map(
+        lambda s: s.getint('images_y_spacing', fallback=1)
+    ).value_or(1)
     return ycoords(TERM.height, img_height, paddingy)
 
 def gallery_page_spacing_config():
     settings = utils.get_config_section('lscat')
-    if not settings:
-        return 23
-    return settings.getint('gallery_page_spacing', fallback=23)
+    return settings.map(
+        lambda s: s.getint('gallery_page_spacing', fallback=23)
+    ).value_or(23)
 
 def users_page_spacing_config():
     settings = utils.get_config_section('lscat')
-    if not settings:
-        return 20
-    return settings.getint('users_page_spacing', fallback=20)
+    return settings.map(
+        lambda s: s.getint('users_page_spacing', fallback=20)
+    ).value_or(20)
 
 def thumbnail_size_config():
     settings = utils.get_config_section('lscat')
-    if not settings:
-        return 310
-    return settings.getint('image_thumbnail_size', fallback=310)
+    return settings.map(
+        lambda s: s.getint('image_thumbnail_size', fallback=310)
+    ).value_or(310)
 
 def get_gen_users_settings():
     settings = utils.get_config_section('lscat')
-    if not settings:
-        return 18, 2
-    message_xcoord = settings.getint('users_print_name_xcoord', fallback=18)
-    padding = settings.getint('images_x_spacing', fallback=2)
-    return message_xcoord, padding
+    return (
+        settings.map(
+            lambda s: s.getint('users_print_name_xcoord', fallback=18)
+        ).value_or(18),
+        settings.map(lambda s: s.getint('images_x_spacing', fallback=2)).value_or(2)
+    )
 
 
 def icat(args):
@@ -97,11 +99,9 @@ def show_instant(cls, data, check_noprint=False):
     if check_noprint and not utils.check_noprint():
         number_of_cols = ncols_config()
 
-        spacing = utils.get_settings('lscat', 'gallery_print_spacing')
-        if spacing:
-            spacing = spacing.split(',')
-        else:
-            spacing = (9, 17, 17, 17, 17)
+        spacing = utils.get_settings('lscat', 'gallery_print_spacing').map(
+                    lambda s: s.split(',')
+                  ).value_or((9, 17, 17, 17, 17))
 
         for (idx, space) in enumerate(spacing[:number_of_cols]):
             print(' ' * int(space), end='')

--- a/koneko/lscat.py
+++ b/koneko/lscat.py
@@ -96,7 +96,7 @@ def show_instant(cls, data, check_noprint=False):
          for x in os.listdir(data.download_path)
          if not x.startswith('.')]
 
-    if check_noprint and not utils.check_noprint():
+    if check_noprint and not utils.check_noprint().value_or(False):
         number_of_cols = ncols_config()
 
         spacing = utils.get_settings('lscat', 'gallery_print_spacing').map(

--- a/koneko/utils.py
+++ b/koneko/utils.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from configparser import ConfigParser
 
 import funcy
+from returns.result import safe, Success
 
 from koneko import lscat
 
@@ -166,30 +167,22 @@ def config() -> ('config', str):
 
     return credentials, your_id
 
-def get_config_section(section: str) -> 'config':
+@safe
+def get_config_section(section: str) -> 'Result[config]':
     config_object = ConfigParser()
     config_path = Path('~/.config/koneko/config.ini').expanduser()
-    if not config_path.exists():
-        return False
-
     config_object.read(config_path)
     section = config_object[section]
     return section
 
-def get_settings(section: str, setting: str) -> str:
-    cfgsection = get_config_section(section)
-    if not cfgsection:
-        return False
-    return cfgsection.get(setting, '')
+def get_settings(section: str, setting: str) -> 'Result[str]':
+    cfgsection: 'Result[config]' = get_config_section(section)
+    return cfgsection.map(lambda c: c.get(setting, ''))
 
-def check_noprint() -> bool:
+@safe
+def check_noprint() -> 'Result[bool]':
     section = get_config_section('misc')
-    if not section:
-        return False
-    try:
-        return section.getboolean('noprint', fallback=False)
-    except ValueError:
-        return False
+    return section.map(lambda s: s.getboolean('noprint', fallback=False)).value_or(False)
 
 def noprint(func: 'func[T]', *args, **kwargs) -> 'T':
     import contextlib

--- a/koneko/utils.py
+++ b/koneko/utils.py
@@ -182,7 +182,7 @@ def get_settings(section: str, setting: str) -> 'Result[str]':
 @safe
 def check_noprint() -> 'Result[bool]':
     section = get_config_section('misc')
-    return section.map(lambda s: s.getboolean('noprint', fallback=False)).value_or(False)
+    return section.map(lambda s: s.getboolean('noprint', fallback=False)).value_or(True)
 
 def noprint(func: 'func[T]', *args, **kwargs) -> 'T':
     import contextlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ cytoolz~=0.10
 PixivPy~=3.5
 blessed~=1.17
 pytest~=5.4
+returns~=0.14

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "cytoolz~=0.10",
         "PixivPy~=3.5",
         "blessed~=1.17",
+        "returns~=0.14"
     ],
     extras_requires = ["pytest~=5.4"],
     entry_points={


### PR DESCRIPTION
Compare to using `or` in the `use-or` branch

https://github.com/twenty5151/koneko/blob/3945099119f2c85b7729a4ef2c726621e0d15ba0/koneko/lscat.py#L39

https://github.com/twenty5151/koneko/blob/3945099119f2c85b7729a4ef2c726621e0d15ba0/koneko/utils.py#L183

## Advantages of using Result
* Functions in utils.py very clean
https://github.com/twenty5151/koneko/blob/c80fbb50338981f73be3a6e0e851cb13e80ed3fe/koneko/utils.py#L170-L176
https://github.com/twenty5151/koneko/blob/c80fbb50338981f73be3a6e0e851cb13e80ed3fe/koneko/utils.py#L178-L180
https://github.com/twenty5151/koneko/blob/c80fbb50338981f73be3a6e0e851cb13e80ed3fe/koneko/utils.py#L182-L185
* Spacing can be immediately assigned to
https://github.com/twenty5151/koneko/blob/c80fbb50338981f73be3a6e0e851cb13e80ed3fe/koneko/lscat.py#L102-L104
    * (Old version for comparison):
https://github.com/twenty5151/koneko/blob/3dc728f89090ab046f690129fcd6a9053955f3ea/koneko/lscat.py#L100-L104
    * (Using or; for comparison. Using or looks good too)
https://github.com/twenty5151/koneko/blob/3945099119f2c85b7729a4ef2c726621e0d15ba0/koneko/lscat.py#L88-L90

## Disadvantages of using Result
* lscat functions not so clean
https://github.com/twenty5151/koneko/blob/c80fbb50338981f73be3a6e0e851cb13e80ed3fe/koneko/lscat.py#L50-L58
https://github.com/twenty5151/koneko/blob/c80fbb50338981f73be3a6e0e851cb13e80ed3fe/koneko/lscat.py#L78-L85
* Need to fix tests


## Advantages of `use-or`
* More pythonic
* One less external dependency

## Disadvantages of `use-or`
* Ugly try-catch still exists
https://github.com/twenty5151/koneko/blob/3945099119f2c85b7729a4ef2c726621e0d15ba0/koneko/utils.py#L187-L190
* Still need to early return missing path
https://github.com/twenty5151/koneko/blob/3945099119f2c85b7729a4ef2c726621e0d15ba0/koneko/utils.py#L171-L173
https://github.com/twenty5151/koneko/blob/3945099119f2c85b7729a4ef2c726621e0d15ba0/koneko/utils.py#L180-L182